### PR TITLE
chore: added GitHub Actions workflow for automatic NuGet publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0'
+
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Execute publish script
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: |
+        chmod +x "$(pwd)/publish.sh"
+        "$(pwd)/publish.sh"


### PR DESCRIPTION
**Summary:**
This PR introduces a GitHub Actions workflow to automatically publish the `Utxorpc.Sdk` to NuGet whenever a new release is created. The workflow runs on Ubuntu and uses the existing `publish.sh` script for packaging and publishing.

**Changes:**
- **GitHub Actions Workflow:** Added a new workflow configuration to automate NuGet package publishing on release events.
- **Script Execution:** Configured the workflow to execute `publish.sh`, which handles the packaging and publishing of the NuGet package.

**Requirements:**
- **NuGet API Key:** Ensure that the NuGet API key is added to GitHub Secrets with the name `NUGET_API_KEY` to enable publishing.