### PR TITLE
chore: enabled adding configs to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,54 @@ The `SyncServiceClient` allows you to fetch blocks and follow chain tips with ea
 ```csharp
 using Utxorpc.Sdk;
 using Utxorpc.Sdk.Models;
+using Utxorpc.Sdk.Models.Enums;
 
-var syncServiceClient = new SyncServiceClient("http://localhost:50051");
-
-BlockRef blockRef = new BlockRef("1dace9bc646e9225251db04ff27397c199b04ec3f83c94cad28c438c3e7eeb50", 67823979);
-Block? block = await syncServiceClient.FetchBlockAsync(blockRef);
-
-if (block is not null)
+var headers = new Dictionary<string, string>
 {
-    Console.WriteLine($"Block Hash: {block.Hash}");
-    Console.WriteLine($"Slot: {block.Slot}");
-    Console.WriteLine($"Native Bytes: {BitConverter.ToString(block.NativeBytes)}");
-}
-else
+    { "dmtr-api-key", "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6" },
+};
+
+var client = new SyncServiceClient(
+    url: "https://preview.utxorpc-v0.demeter.run",
+    headers
+);
+
+await foreach (NextResponse? response in client.FollowTipAsync(
+    new BlockRef
+    (
+        "b977e548f3364b114505f3311a10f89e5f5cf47e815765bce6750a5de48e5951",
+        58717900
+    )))
 {
-    Console.WriteLine("Block not found.");
+    Console.WriteLine("___________________");
+    switch (response.Action)
+    {
+        case NextResponseAction.Apply:
+            Block? applyBlock = response.AppliedBlock;
+            if (applyBlock is not null)
+            {
+                Console.WriteLine($"Apply Block: {applyBlock.Hash} Slot: {applyBlock.Slot}");
+                Console.WriteLine($"Cbor: {Convert.ToHexString(applyBlock.NativeBytes ?? [])}");
+            }
+            break;
+        case NextResponseAction.Undo:
+            Block? undoBlock = response.UndoneBlock;
+            if (undoBlock is not null)
+            {
+                Console.WriteLine($"Undo Block: {undoBlock.Hash} Slot: {undoBlock.Slot}");
+            }
+            break;
+        case NextResponseAction.Reset:
+            BlockRef? resetRef = response.ResetRef;
+            if (resetRef is not null)
+            {
+                Console.WriteLine($"Reset to Block: {resetRef.Hash} Slot: {resetRef.Index}");
+            }
+            break;
+    }
+    Console.WriteLine("___________________");
 }
+
 
 ```
 

--- a/src/Utxorpc.Sdk.Example/Program.cs
+++ b/src/Utxorpc.Sdk.Example/Program.cs
@@ -2,13 +2,21 @@
 using Utxorpc.Sdk.Models;
 using Utxorpc.Sdk.Models.Enums;
 
-SyncServiceClient? syncServiceClient = new("http://localhost:50051");
+var headers = new Dictionary<string, string>
+{
+    { "dmtr-api-key", "dmtr_utxorpc1vc0m93rynmltysttwm7ns9m3n5cklws6" },
+};
 
-await foreach (NextResponse? response in syncServiceClient.FollowTipAsync(
+var client = new SyncServiceClient(
+    url: "https://preview.utxorpc-v0.demeter.run",
+    headers
+);
+
+await foreach (NextResponse? response in client.FollowTipAsync(
     new BlockRef
     (
-        "1dace9bc646e9225251db04ff27397c199b04ec3f83c94cad28c438c3e7eeb50",
-        67823979
+        "b977e548f3364b114505f3311a10f89e5f5cf47e815765bce6750a5de48e5951",
+        58717900
     )))
 {
     Console.WriteLine("___________________");

--- a/src/Utxorpc.Sdk/QueryServiceClient.cs
+++ b/src/Utxorpc.Sdk/QueryServiceClient.cs
@@ -3,9 +3,31 @@ using Utxorpc.V1alpha.Query;
 
 namespace Utxorpc.Sdk;
 
-public class QueryServiceClient(string url)
+public class QueryServiceClient
 {
-    private readonly QueryService.QueryServiceClient _client = new(GrpcChannel.ForAddress(url));
+    private readonly QueryService.QueryServiceClient _client;
+
+    public QueryServiceClient(string url, IDictionary<string, string>? headers = null)
+    {
+        var httpClientHandler = new HttpClientHandler();
+        var httpClient = new HttpClient(httpClientHandler);
+        
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        var channelOptions = new GrpcChannelOptions
+        {
+            HttpClient = httpClient
+        };
+
+        var channel = GrpcChannel.ForAddress(url, channelOptions);
+        _client = new QueryService.QueryServiceClient(channel);
+    }
 
     // TODO: Implement ReadData, ReadParams, ReadUtxos, SearchUtxos methods
 }

--- a/src/Utxorpc.Sdk/SubmitServiceClient.cs
+++ b/src/Utxorpc.Sdk/SubmitServiceClient.cs
@@ -3,9 +3,30 @@ using Utxorpc.V1alpha.Submit;
 
 namespace Utxorpc.Sdk;
 
-public class SubmitServiceClient(string url)
+public class SubmitServiceClient
 {
-    private readonly SubmitService.SubmitServiceClient _client = new(GrpcChannel.ForAddress(url));
+    private readonly SubmitService.SubmitServiceClient _client;
 
+    public SubmitServiceClient(string url, IDictionary<string, string>? headers = null)
+    {
+        var httpClientHandler = new HttpClientHandler();
+        var httpClient = new HttpClient(httpClientHandler);
+        
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        var channelOptions = new GrpcChannelOptions
+        {
+            HttpClient = httpClient
+        };
+
+        var channel = GrpcChannel.ForAddress(url, channelOptions);
+        _client = new SubmitService.SubmitServiceClient(channel);
+    }
     // TODO: Implement EvalTx, ReadMempool, SubmitTx, WaitForTx, WatchMempool methods
 }

--- a/src/Utxorpc.Sdk/SyncServiceClient.cs
+++ b/src/Utxorpc.Sdk/SyncServiceClient.cs
@@ -8,9 +8,31 @@ using BlockRef = Utxorpc.Sdk.Models.BlockRef;
 
 namespace Utxorpc.Sdk;
 
-public class SyncServiceClient(string url)
+public class SyncServiceClient
 {
-    private readonly SyncService.SyncServiceClient _client = new(GrpcChannel.ForAddress(url));
+    private readonly SyncService.SyncServiceClient _client;
+
+    public SyncServiceClient(string url, IDictionary<string, string>? headers = null)
+    {
+        var httpClientHandler = new HttpClientHandler();
+        var httpClient = new HttpClient(httpClientHandler);
+        
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        var channelOptions = new GrpcChannelOptions
+        {
+            HttpClient = httpClient
+        };
+
+        var channel = GrpcChannel.ForAddress(url, channelOptions);
+        _client = new SyncService.SyncServiceClient(channel);
+    }
 
     public async Task<Block?> FetchBlockAsync(BlockRef blockRef)
     {

--- a/src/Utxorpc.Sdk/WatchServiceClient.cs
+++ b/src/Utxorpc.Sdk/WatchServiceClient.cs
@@ -3,9 +3,31 @@ using Utxorpc.V1alpha.Watch;
 
 namespace Utxorpc.Sdk;
 
-public class WatchServiceClient(string url)
+public class WatchServiceClient
 {
-    private readonly WatchService.WatchServiceClient _client = new(GrpcChannel.ForAddress(url));
+    private readonly WatchService.WatchServiceClient _client;
 
+    public WatchServiceClient(string url, IDictionary<string, string>? headers = null)
+    {
+        var httpClientHandler = new HttpClientHandler();
+        var httpClient = new HttpClient(httpClientHandler);
+        
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        var channelOptions = new GrpcChannelOptions
+        {
+            HttpClient = httpClient
+        };
+
+        var channel = GrpcChannel.ForAddress(url, channelOptions);
+        _client = new WatchService.WatchServiceClient(channel);
+    }
+    
     // TODO: Implement WatchTx method
 }


### PR DESCRIPTION
### Summary:

- **Feature**: Added support for custom HTTP headers in all Clients.
  - Updated the constructors to accept optional headers and `GrpcChannelOptions` for more flexible configurations when creating a gRPC channel.
  - Headers are passed through an `HttpClient` in `GrpcChannelOptions`, allowing for customization (e.g., authorization tokens, custom headers).
- **Improvement**: Maintained backward compatibility by using default options when no custom configuration is provided, while enabling advanced use cases with additional options.
- **ReadMe**: Changed example to use FollowTip() while also using a UTxORPC compatible node which will work if ran as is.