### PR TITLE
feat: update to Utxorpc.Spec 0.18.1-alpha

### DIFF
--- a/src/Utxorpc.Sdk/Models/AnyUtxoData.cs
+++ b/src/Utxorpc.Sdk/Models/AnyUtxoData.cs
@@ -3,5 +3,6 @@ namespace Utxorpc.Sdk.Models;
 public record AnyUtxoData(
     byte[]? NativeBytes,
     TxoRef? TxoRef,
-    object? ParsedState = null 
+    object? ParsedState = null,
+    ChainPoint? BlockRef = null
 );

--- a/src/Utxorpc.Sdk/Models/BlockRef.cs
+++ b/src/Utxorpc.Sdk/Models/BlockRef.cs
@@ -2,5 +2,7 @@ namespace Utxorpc.Sdk.Models;
 
 public record BlockRef(
     string Hash,
-    ulong Index
+    ulong Slot,
+    ulong? Height = null,
+    ulong? Timestamp = null
 );

--- a/src/Utxorpc.Sdk/Models/ChainPoint.cs
+++ b/src/Utxorpc.Sdk/Models/ChainPoint.cs
@@ -1,6 +1,8 @@
 namespace Utxorpc.Sdk.Models;
 
 public record ChainPoint(
-    ulong? Slot,
-    byte[]? Hash 
+    ulong Slot,
+    byte[] Hash,
+    ulong Height,
+    ulong Timestamp
 );

--- a/src/Utxorpc.Sdk/Models/Enums/WatchTxAction.cs
+++ b/src/Utxorpc.Sdk/Models/Enums/WatchTxAction.cs
@@ -3,5 +3,6 @@ namespace Utxorpc.Sdk.Models.Enums;
 public enum WatchTxAction
 {
     Apply,
-    Undo
+    Undo,
+    Idle
 }

--- a/src/Utxorpc.Sdk/Models/NextResponse.cs
+++ b/src/Utxorpc.Sdk/Models/NextResponse.cs
@@ -5,5 +5,6 @@ public record NextResponse(
     NextResponseAction Action,
     Block? AppliedBlock = null,
     Block? UndoneBlock = null,
-    BlockRef? ResetRef = null
+    BlockRef? ResetRef = null,
+    BlockRef? Tip = null
 );

--- a/src/Utxorpc.Sdk/Models/WatchTxResponse.cs
+++ b/src/Utxorpc.Sdk/Models/WatchTxResponse.cs
@@ -4,6 +4,7 @@ namespace Utxorpc.Sdk.Models;
 
 public record WatchTxResponse(
     WatchTxAction Action,
-    byte[]? Raw,
-    object? ParsedState = null
+    byte[]? Raw = null,
+    object? ParsedState = null,
+    BlockRef? IdleBlockRef = null
 );

--- a/src/Utxorpc.Sdk/QueryServiceClient.cs
+++ b/src/Utxorpc.Sdk/QueryServiceClient.cs
@@ -99,4 +99,22 @@ public class QueryServiceClient
         SpecReadParamsResponse response = await _client.ReadParamsAsync(request);
         return DataUtils.FromSpecReadParamsResponse(response);
     }
+
+    public async Task<ReadGenesisResponse> ReadGenesisAsync(FieldMask? fieldMask = null)
+    {
+        ReadGenesisRequest request = new()
+        {
+            FieldMask = fieldMask
+        };
+        return await _client.ReadGenesisAsync(request);
+    }
+
+    public async Task<ReadEraSummaryResponse> ReadEraSummaryAsync(FieldMask? fieldMask = null)
+    {
+        ReadEraSummaryRequest request = new()
+        {
+            FieldMask = fieldMask
+        };
+        return await _client.ReadEraSummaryAsync(request);
+    }
 }

--- a/src/Utxorpc.Sdk/SubmitServiceClient.cs
+++ b/src/Utxorpc.Sdk/SubmitServiceClient.cs
@@ -42,19 +42,23 @@ public class SubmitServiceClient
 
     public async Task<SubmitTxResponse> SubmitTxAsync(Tx[] txs)
     {
-        SubmitTxRequest request = new();
+        List<byte[]> refs = [];
 
-        foreach (Tx key in txs)
+        foreach (Tx tx in txs)
         {
-            AnyChainTx protoRef = new()
+            SubmitTxRequest request = new()
             {
-                Raw = ByteString.CopyFrom(key.Raw)
+                Tx = new AnyChainTx
+                {
+                    Raw = ByteString.CopyFrom(tx.Raw)
+                }
             };
-            request.Tx.Add(protoRef);
+
+            SpecSubmitTxResponse response = await _client.SubmitTxAsync(request);
+            refs.Add(response.Ref.ToByteArray());
         }
 
-        SpecSubmitTxResponse response = await _client.SubmitTxAsync(request);
-        return DataUtils.FromSpecSubmitTxResponse(response);
+        return new SubmitTxResponse(refs);
     }
 
     public async IAsyncEnumerable<WatchMempoolResponse> WatchMempoolAsync(Predicate predicate, FieldMask? fieldMask, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/src/Utxorpc.Sdk/SyncServiceClient.cs
+++ b/src/Utxorpc.Sdk/SyncServiceClient.cs
@@ -140,27 +140,29 @@ public class SyncServiceClient
         using AsyncServerStreamingCall<FollowTipResponse>? call = _client.FollowTip(request, cancellationToken: cancellationToken);
         await foreach (FollowTipResponse? response in call.ResponseStream.ReadAllAsync(cancellationToken))
         {
+            BlockRef? tip = DataUtils.FromSyncBlockRef(response.Tip);
+
             switch (response.ActionCase)
             {
                 case FollowTipResponse.ActionOneofCase.Apply:
                     Block? applyBlock = DataUtils.FromAnyChainBlock(response.Apply);
                     if (applyBlock is not null)
                     {
-                        yield return DataUtils.CreateApplyResponse(applyBlock);
+                        yield return DataUtils.CreateApplyResponse(applyBlock, tip);
                     }
                     break;
                 case FollowTipResponse.ActionOneofCase.Undo:
                     Block? undoBlock = DataUtils.FromAnyChainBlock(response.Undo);
                     if (undoBlock is not null)
                     {
-                        yield return DataUtils.CreateUndoResponse(undoBlock);
+                        yield return DataUtils.CreateUndoResponse(undoBlock, tip);
                     }
                     break;
                 case FollowTipResponse.ActionOneofCase.Reset:
                     BlockRef? resetRef = DataUtils.FromSyncBlockRef(response.Reset);
                     if (resetRef != null)
                     {
-                        yield return DataUtils.CreateResetResponse(resetRef);
+                        yield return DataUtils.CreateResetResponse(resetRef, tip);
                     }
                     break;
             }

--- a/src/Utxorpc.Sdk/Utils/DataUtils.cs
+++ b/src/Utxorpc.Sdk/Utils/DataUtils.cs
@@ -58,20 +58,23 @@ public static class DataUtils
     public static BlockRef? FromSyncBlockRef(SpecSyncBlockRef? syncBlockRef)
     {
         if (syncBlockRef == null) return null;
-        
+
         return new BlockRef(
             Convert.ToHexString(syncBlockRef.Hash.ToByteArray()),
-            syncBlockRef.Index
+            syncBlockRef.Slot,
+            syncBlockRef.Height,
+            syncBlockRef.Timestamp
         );
     }
 
     public static BlockRef? FromWatchBlockRef(SpecWatchBlockRef? watchBlockRef)
     {
         if (watchBlockRef == null) return null;
-        
+
         return new BlockRef(
             Convert.ToHexString(watchBlockRef.Hash.ToByteArray()),
-            watchBlockRef.Index
+            watchBlockRef.Slot,
+            watchBlockRef.Height
         );
     }
 
@@ -80,7 +83,9 @@ public static class DataUtils
         return new SpecSyncBlockRef
         {
             Hash = ByteString.CopyFrom(Convert.FromHexString(blockRef.Hash)),
-            Index = blockRef.Index
+            Slot = blockRef.Slot,
+            Height = blockRef.Height ?? 0,
+            Timestamp = blockRef.Timestamp ?? 0
         };
     }
 
@@ -89,7 +94,8 @@ public static class DataUtils
         return new SpecWatchBlockRef
         {
             Hash = ByteString.CopyFrom(Convert.FromHexString(blockRef.Hash)),
-            Index = blockRef.Index
+            Slot = blockRef.Slot,
+            Height = blockRef.Height ?? 0
         };
     }
 
@@ -142,7 +148,7 @@ public static class DataUtils
     public static SubmitTxResponse FromSpecSubmitTxResponse(SpecSubmitTxResponse specResponse)
     {
         return new SubmitTxResponse(
-            [.. specResponse.Ref.Select(r => r.ToByteArray())]
+            [specResponse.Ref.ToByteArray()]
         );
     }
 
@@ -208,10 +214,12 @@ public static class DataUtils
     public static ChainPoint? FromSpecChainPoint(SpecChainPoint? specChainPoint)
     {
         if (specChainPoint == null) return null;
-        
+
         return new ChainPoint(
             specChainPoint.Slot,
-            specChainPoint.Hash.ToByteArray()
+            specChainPoint.Hash.ToByteArray(),
+            specChainPoint.Height,
+            specChainPoint.Timestamp
         );
     }
 

--- a/src/Utxorpc.Sdk/Utils/DataUtils.cs
+++ b/src/Utxorpc.Sdk/Utils/DataUtils.cs
@@ -100,38 +100,35 @@ public static class DataUtils
     }
 
     // NextResponse creation methods
-    public static NextResponse CreateApplyResponse(Block block) => 
-        new(NextResponseAction.Apply, AppliedBlock: block);
+    public static NextResponse CreateApplyResponse(Block block, BlockRef? tip = null) =>
+        new(NextResponseAction.Apply, AppliedBlock: block, Tip: tip);
 
-    public static NextResponse CreateUndoResponse(Block block) => 
-        new(NextResponseAction.Undo, UndoneBlock: block);
+    public static NextResponse CreateUndoResponse(Block block, BlockRef? tip = null) =>
+        new(NextResponseAction.Undo, UndoneBlock: block, Tip: tip);
 
-    public static NextResponse CreateResetResponse(BlockRef? blockRef) => 
-        new(NextResponseAction.Reset, ResetRef: blockRef);
+    public static NextResponse CreateResetResponse(BlockRef? blockRef, BlockRef? tip = null) =>
+        new(NextResponseAction.Reset, ResetRef: blockRef, Tip: tip);
 
     // Watch service conversion methods
     public static WatchTxResponse FromSpecWatchTxResponse(SpecWatchTxResponse specResponse)
     {
-        WatchTxAction action;
-        SpecWatch.AnyChainTx? tx;
-        
-        switch (specResponse.ActionCase)
+        return specResponse.ActionCase switch
         {
-            case SpecWatchTxResponse.ActionOneofCase.Apply:
-                action = WatchTxAction.Apply;
-                tx = specResponse.Apply;
-                break;
-            case SpecWatchTxResponse.ActionOneofCase.Undo:
-                action = WatchTxAction.Undo;
-                tx = specResponse.Undo;
-                break;
-            default:
-                throw new InvalidOperationException($"Unknown WatchTxResponse action: {specResponse.ActionCase}");
-        }
-        
+            SpecWatchTxResponse.ActionOneofCase.Apply => FromWatchTxAction(WatchTxAction.Apply, specResponse.Apply),
+            SpecWatchTxResponse.ActionOneofCase.Undo => FromWatchTxAction(WatchTxAction.Undo, specResponse.Undo),
+            SpecWatchTxResponse.ActionOneofCase.Idle => new WatchTxResponse(
+                WatchTxAction.Idle,
+                IdleBlockRef: FromWatchBlockRef(specResponse.Idle)
+            ),
+            _ => throw new InvalidOperationException($"Unknown WatchTxResponse action: {specResponse.ActionCase}")
+        };
+    }
+
+    private static WatchTxResponse FromWatchTxAction(WatchTxAction action, SpecWatch.AnyChainTx? tx)
+    {
         byte[]? raw = null;
         object? parsedState = null;
-        
+
         if (tx is not null)
         {
             parsedState = tx.ChainCase switch
@@ -140,7 +137,7 @@ public static class DataUtils
                 _ => throw new InvalidOperationException($"Unsupported chain type: {tx.ChainCase}"),
             };
         }
-        
+
         return new WatchTxResponse(action, raw, parsedState);
     }
 
@@ -226,11 +223,12 @@ public static class DataUtils
     public static AnyUtxoData? FromSpecAnyUtxoData(SpecAnyUtxoData? specUtxoData)
     {
         if (specUtxoData == null) return null;
-        
+
         return new AnyUtxoData(
             specUtxoData.NativeBytes.ToByteArray(),
             FromSpecTxoRef(specUtxoData.TxoRef),
-            specUtxoData.ParsedStateCase == SpecAnyUtxoData.ParsedStateOneofCase.Cardano ? specUtxoData.Cardano : null
+            specUtxoData.ParsedStateCase == SpecAnyUtxoData.ParsedStateOneofCase.Cardano ? specUtxoData.Cardano : null,
+            FromSpecChainPoint(specUtxoData.BlockRef)
         );
     }
 

--- a/src/Utxorpc.Sdk/Utxorpc.Sdk.csproj
+++ b/src/Utxorpc.Sdk/Utxorpc.Sdk.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Utxorpc.Spec" Version="0.16.0-alpha" />
+    <PackageReference Include="Utxorpc.Spec" Version="0.18.1-alpha" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update SDK to support spec version 0.18.1-alpha with breaking changes in BlockRef and ChainPoint models.

Changes:
- Update BlockRef model to include Slot, Height, and Timestamp fields
- Update ChainPoint model to include Height and Timestamp fields
- Handle differences between Watch.BlockRef (3 fields) and Sync.BlockRef (4 fields)
- Update DataUtils conversions for new field structure
- Refactor SubmitServiceClient to use individual submission API
- Add ReadGenesis and ReadEraSummary methods to QueryServiceClient
- Upgrade Utxorpc.Spec from 0.16.0-alpha to 0.18.1-alpha

Breaking Changes:
- BlockRef constructor signature changed from (Hash, Index) to (Hash, Slot, Height?, Timestamp?)
- ChainPoint constructor signature changed from (Slot?, Hash?) to (Slot, Hash, Height, Timestamp)
- Index property renamed to Height and Slot added as separate field